### PR TITLE
tests: implement mocking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ ignore_missing_imports = true
 module = [
     "caikit",
     "caikit.*",
+    "caikit_nlp.",
+    "caikit_nlp.*",
     "grpc",
     "grpc_health.v1",
     "caikit.runtime.grpc_server",

--- a/src/caikit_nlp_client/http_client.py
+++ b/src/caikit_nlp_client/http_client.py
@@ -29,7 +29,9 @@ class HTTPCaikitNlpClient:
         protocol = "https" if (http_config.mtls or http_config.tls) else "http"
         base_url = f"{protocol}://{http_config.host}:{http_config.port}"
         text_generation_endpoint = "/api/v1/task/text-generation"
-        text_generation_stream_endpoint = "/api/v1/task/server-streaming-text"
+        text_generation_stream_endpoint = (
+            "/api/v1/task/server-streaming-text-generation"
+        )
 
         self.api_url = f"{base_url}{text_generation_endpoint}"
         self.stream_api_url = f"{base_url}{text_generation_stream_endpoint}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import socket
 import time
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Callable, TypeVar
 
@@ -106,10 +107,8 @@ def channel(grpc_server_port, grpc_server):
     return channel_factory("localhost", grpc_server_port)
 
 
-# TODO: make this session (or module) scoped, this will mean having to fix
-# the configuration so that it can be session-scoped (monkeypatch does not like this)
 @pytest.fixture
-def grpc_server(caikit_nlp_runtime, grpc_server_port):
+def grpc_server(caikit_nlp_runtime, grpc_server_port, mock_text_generation):
     from caikit.runtime.grpc_server import RuntimeGRPCServer
 
     grpc_server = RuntimeGRPCServer()
@@ -140,7 +139,117 @@ def http_config(caikit_nlp_runtime):
 
 
 @pytest.fixture
-def http_server(caikit_nlp_runtime, http_config):
+def caikit_test_producer():
+    from caikit.interfaces.nlp.data_model.text_generation import ProducerId
+
+    yield ProducerId(
+        name="Testing Producer",
+        version="0.0.1",
+    )
+
+
+@pytest.fixture
+def generated_text():
+    yield "mocked generated text result"
+
+
+@pytest.fixture
+def generated_text_result(caikit_test_producer, generated_text):
+    from caikit.interfaces.nlp.data_model.text_generation import (
+        FinishReason,
+        GeneratedTextResult,
+    )
+
+    yield GeneratedTextResult(
+        generated_text="mocked generated text result",
+        generated_tokens=42,
+        finish_reason=FinishReason.EOS_TOKEN,
+        producer_id=caikit_test_producer,
+        input_token_count=10,
+        seed=None,  # Optional[np.uint64]
+    )
+
+
+# FIXME: Validate text stream mocking. There's a lot of logic here.
+#        Can this be simplified?
+@pytest.fixture
+def generated_text_stream_result(caikit_test_producer, generated_text):
+    from caikit.interfaces.nlp.data_model.text_generation import (
+        FinishReason,
+        GeneratedTextStreamResult,
+        GeneratedToken,
+        TokenStreamDetails,
+    )
+
+    split_text = generated_text.split(" ")
+
+    # TODO: validate token_list
+    token_list = [GeneratedToken(text="dummy generated token value", logprob=0.42)]
+    input_token_count = len(split_text)
+
+    result = []
+    for text in split_text:
+        details = TokenStreamDetails(
+            finish_reason=FinishReason.NOT_FINISHED,
+            generated_tokens=42,  # FIXME: is this correct?
+            seed=None,
+            input_token_count=input_token_count,
+        )
+
+        stream_result = GeneratedTextStreamResult(
+            generated_text=text,
+            tokens=token_list,
+            details=details,
+        )
+
+        result.append(stream_result)
+
+    result[-1].details.finish_reason = FinishReason.EOS_TOKEN
+    return result
+
+
+@pytest.fixture
+def mock_text_generation(
+    generated_text_result, generated_text_stream_result, monkeypatch
+):
+    # import caikit_nlp.modules.text_generation.text_generation_local
+    import caikit_nlp.modules.text_generation.text_generation_tgis
+    from caikit.interfaces.nlp.data_model.text_generation import (
+        GeneratedTextResult,
+        GeneratedTextStreamResult,
+    )
+
+    # NOTE: config uses tgis, so this is not really required,
+    #       unless we want to test the local text generation module
+    # monkeypatch.setattr(
+    #     caikit_nlp.modules.text_generation.text_generation_local,
+    #     "generate_text_func",
+    #     lambda: generated_text_result,
+    # )
+
+    class StubTGISGenerationClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def unary_generate(self, *args, **kwargs) -> GeneratedTextResult:
+            return generated_text_result
+
+        def stream_generate(
+            self, *args, **kwargs
+        ) -> Iterable[GeneratedTextStreamResult]:
+            yield from generated_text_stream_result
+
+    monkeypatch.setattr(
+        caikit_nlp.modules.text_generation.text_generation_tgis,
+        "TGISGenerationClient",
+        StubTGISGenerationClient,
+    )
+
+    yield
+
+
+@pytest.fixture
+def http_server(caikit_nlp_runtime, http_config, mock_text_generation):
     from caikit.runtime.http_server import RuntimeHTTPServer
 
     http_server = RuntimeHTTPServer()

--- a/tests/test_grpc_client_introspection.py
+++ b/tests/test_grpc_client_introspection.py
@@ -8,15 +8,17 @@ def connected_client(channel):
     return GrpcCaikitNlpClientIntrospection(channel)
 
 
-def test_generate_text(model_name, connected_client):
+def test_generate_text(model_name, connected_client, generated_text_result):
     generated_text = connected_client.generate_text(
         model_name, "What does foobar mean?"
     )
 
-    assert generated_text
+    assert generated_text == generated_text_result.generated_text
 
 
-def test_generate_text_with_optional_args(connected_client, model_name):
+def test_generate_text_with_optional_args(
+    connected_client, model_name, generated_text_result
+):
     generated_text = connected_client.generate_text(
         model_name,
         "What does foobar mean?",
@@ -24,7 +26,8 @@ def test_generate_text_with_optional_args(connected_client, model_name):
         max_new_tokens=20,
         min_new_tokens=4,
     )
-    assert generated_text
+    assert generated_text == generated_text_result.generated_text
+    # TODO: also validate passing of parameters
 
 
 def test_generate_text_with_no_model_id(connected_client):
@@ -32,25 +35,29 @@ def test_generate_text_with_no_model_id(connected_client):
         connected_client.generate_text("", "What does foobar mean?")
 
 
-@pytest.mark.xfail(
-    reason="BertForSequenceClassification-caikit does not support streaming"
-)
-def test_generate_text_stream(model_name, connected_client):
-    results = connected_client.generate_text_stream(
+def test_generate_text_stream(
+    model_name, connected_client, generated_text_stream_result
+):
+    result = connected_client.generate_text_stream(
         model_name, "What is the meaning of life?"
     )
-    assert results
+
+    assert result == [
+        stream_part.generated_text for stream_part in generated_text_stream_result
+    ]
 
 
-@pytest.mark.xfail(
-    reason="BertForSequenceClassification-caikit does not support streaming"
-)
-def test_generate_text_stream_with_optional_args(model_name, connected_client):
-    results = connected_client.generate_text_stream(
+def test_generate_text_stream_with_optional_args(
+    model_name, connected_client, generated_text_stream_result
+):
+    result = connected_client.generate_text_stream(
         model_name,
         "What is the meaning of life?",
         preserve_input_text=False,
         max_new_tokens=20,
         min_new_tokens=4,
     )
-    assert results
+    assert result == [
+        stream_part.generated_text for stream_part in generated_text_stream_result
+    ]
+    # TODO: also validate passing of parameters

--- a/tests/test_http_predict.py
+++ b/tests/test_http_predict.py
@@ -8,12 +8,14 @@ def http_client(http_config, http_server) -> HTTPCaikitNlpClient:
     return HTTPCaikitNlpClient(http_config)
 
 
-def test_generate_text(http_client, model_name):
+def test_generate_text(http_client, model_name, generated_text_result):
     response = http_client.generate_text(model_name, "What does foobar mean?")
     assert response
 
 
-def test_generate_text_with_optional_args(http_client, model_name):
+def test_generate_text_with_optional_args(
+    http_client, model_name, generated_text_result
+):
     response = http_client.generate_text(
         model_name,
         "What does foobar mean?",
@@ -21,6 +23,7 @@ def test_generate_text_with_optional_args(http_client, model_name):
         min_new_tokens=4,
     )
     assert response
+    # TODO: also validate passing of parameters
 
 
 def test_generate_text_with_no_model_id(http_client):
@@ -28,21 +31,27 @@ def test_generate_text_with_no_model_id(http_client):
         http_client.generate_text("", "What does foobar mean?")
 
 
-@pytest.mark.skip(reason="HTTP stream is not working as expected")
-def test_generate_text_stream(http_client, model_name):
-    results = http_client.generate_text_stream(
+@pytest.mark.xfail(reason="http client is broken for streaming")
+def test_generate_text_stream(http_client, model_name, generated_text_stream_result):
+    result = http_client.generate_text_stream(
         model_name, "What is the meaning of life?"
     )
-    assert len(results) == 9
+    assert result == [
+        stream_part.generated_text for stream_part in generated_text_stream_result
+    ]
 
 
-@pytest.mark.skip(reason="HTTP stream is not working as expected")
-def test_generate_text_stream_with_optional_args(http_client, model_name):
-    results = http_client.generate_text_stream(
+@pytest.mark.xfail(reason="http client is broken for streaming")
+def test_generate_text_stream_with_optional_args(
+    http_client, model_name, generated_text_stream_result
+):
+    result = http_client.generate_text_stream(
         model_name,
         "What is the meaning of life?",
         preserve_input_text=False,
         max_new_tokens=20,
         min_new_tokens=4,
     )
-    assert len(results) == 9
+    assert result == [
+        stream_part.generated_text for stream_part in generated_text_stream_result
+    ]


### PR DESCRIPTION
By mocking `TGISGenerationClient` we can avoid having to call real models to generate results (and having to setup a TGIS remote).

Please note that there's quite a bit of logic in the streaming endpoint mocking, which we should simplify as much as possible in the future.