### PR TITLE
tests: disable caikit metrics server

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,7 @@ def caikit_nlp_runtime(grpc_server_port, http_server_port, insecure):
     config = {
         "merge_strategy": "merge",
         "runtime": {
+            "metrics": {"enabled": False},
             "local_models_dir": models_directory,
             "library": "caikit_nlp",
             "lazy_load_local_models": True,


### PR DESCRIPTION
avoid spawning metrics server on port 8086 on every run

closes #20 