### PR TITLE
tests: allow for testing using a real caikit+tgis stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ caikit+tgis stack, it is sufficient to run using the `--real-caikit` flag when r
 ```bash
 nox -s tests -- --real-caikit tests
 ```
+
+_Notes:_
+
+- The required images (`caikit-tgis-serving`, `text-generation-inference`), so it could take a while for tests to start while
+  compose is pulling the required images, it may seem like the tests are hanging.
+- This uses a real model ([google/flan-t5-small](https://huggingface.co/google/flan-t5-small)), which will be downloaded
+  to `tests/fixtures/resources/flan-t5-small-caikit` and is around 300MB in size.

--- a/tests/fixtures/resources/.gitignore
+++ b/tests/fixtures/resources/.gitignore
@@ -1,0 +1,1 @@
+/flan-t5-small-caikit

--- a/tests/fixtures/resources/caikit-tgis.yml
+++ b/tests/fixtures/resources/caikit-tgis.yml
@@ -1,0 +1,25 @@
+runtime:
+  library: caikit_nlp
+  local_models_dir: /mnt/models/
+  lazy_load_local_models: true
+
+model_management:
+  finders:
+    default:
+      type: MULTI
+      config:
+        finder_priority:
+          - tgis-auto
+    tgis-auto:
+      type: TGIS-AUTO
+      config:
+        test_connection: true
+  initializers:
+    default:
+      type: LOCAL
+      config:
+        backend_priority:
+          - type: TGIS
+            config:
+              connection:
+                hostname: tgis:8033

--- a/tests/fixtures/resources/docker-compose.yml
+++ b/tests/fixtures/resources/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   caikit:
-    image: quay.io/opendatahub/caikit-tgis-serving:fast
+    image: quay.io/opendatahub/caikit-tgis-serving:stable
     platform: linux/amd64 # allows running this image on apple silicon
     volumes:
       - ./flan-t5-small-caikit/:/mnt/models/ # downloaded when running tests
@@ -8,17 +8,13 @@ services:
     ports:
       - 8085:8085 # grpc
       - 8080:8080 # http
+    environment:
+      - "TRANSFORMERS_CACHE=/tmp/transformers_cache"
   tgis:
     image: quay.io/opendatahub/text-generation-inference:stable
     platform: linux/amd64 # allows running this image on apple silicon
-    command: [
-        "text-generation-launcher", # NOTE:--num-shard defaults to 1
-        "--model-name=/mnt/models/artifacts/",
-        "--max-batch-size=256",
-        "--max-concurrent-requests=64",
-      ]
+    command: ["text-generation-launcher", "--model-name=/mnt/models/artifacts/"]
     volumes:
       - ./flan-t5-small-caikit/:/mnt/models/ # downloaded when running tests
-      - ../../tiny_models/flan-t5-small-caikit/:/mnt/models/
     environment:
       - "TRANSFORMERS_CACHE=/tmp/transformers_cache"


### PR DESCRIPTION
By using `pytest-docker`, we can spin up a real caikit-nlp container with a tgis backend and test against that.

To run tests against a real instance it is enough to run:

```bash
pytest --real-caikit
```

closes #33 