### PR TITLE
gha: output coverage report in xml format

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,10 +46,13 @@ jobs:
 
       - name: Run tests
         run: |
-          nox --session tests-${{ matrix.python }}
+          nox --session tests-${{ matrix.python }} -- --cov-report=xml
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3.1.4
         if: always()
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true

--- a/noxfile.py
+++ b/noxfile.py
@@ -136,11 +136,9 @@ def tests(session: nox.Session) -> None:
     session.install(".[tests]")
     try:
         session.run(
-            "coverage",
-            "run",
-            "--parallel",
-            "-m",
             "pytest",
+            "--cov",
+            "--cov-config=pyproject.toml",
             *session.posargs,
             env={"COVERAGE_FILE": f".coverage.{session.python}"},
         )


### PR DESCRIPTION
xml format should make the coverage report digestible by codecov.io