### PR TITLE
http client: use stream=True to enable requests streaming

### DIFF
--- a/src/caikit_nlp_client/http_client.py
+++ b/src/caikit_nlp_client/http_client.py
@@ -230,6 +230,7 @@ class HttpClient:
             self._stream_api_url,
             json=payload,
             timeout=timeout,
+            stream=True,
             **req_kwargs,  # type: ignore
         )
         log.debug(f"Response: {response}")


### PR DESCRIPTION
we need to provide `stream=True` to actually stream responses

See https://requests.readthedocs.io/en/latest/user/advanced/#streaming-requests
