### PR TITLE
tests: fix parametrization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ from caikit_nlp_client import GrpcClient
 host = "localhost"
 port = 8085
 model_name = "flan-t5-small-caikit"
-grpc_client = GrpcClient(f"http://{host}:{port}", insecure=True)
-# or, with https:
-grpc_client = GrpcClient(f"https://{host}:{port}")
+grpc_client = GrpcClient(host, port)
 
 text = grpc_client.generate_text(model_name, "What is the boiling point of Nitrogen?")
 ```
@@ -70,6 +68,15 @@ http_client = HttpClient(f"https://{host}:{http_port}", ca_cert_path="ca.pem")
 with open("ca.pem", "rb") as fh:
     ca_cert = fh.read()
 grpc_client = GrpcClient(host, grpc_port, ca_cert=ca_cert)
+```
+
+To skip validation altogether:
+
+```python
+# http
+http_client = HttpClient(f"https://{host}:{http_port}", insecure=True)
+# grpc
+grpc_client = GrpcClient(host, port, insecure=True)
 ```
 
 ### mTLS

--- a/src/caikit_nlp_client/http_client.py
+++ b/src/caikit_nlp_client/http_client.py
@@ -69,18 +69,11 @@ class HttpClient:
         self._client_key_path = client_key_path
         self._ca_cert_path = ca_cert_path
         if (
-            any(
-                (
-                    self._client_key_path,
-                    self._client_cert_path,
-                    self._ca_cert_path,
-                )
-            )
+            any((self._client_key_path, self._client_cert_path))
             and not self._mtls_configured
         ):
             raise ValueError(
-                "Must provide both ca_cert_path, client_cert_path, client_key_path "
-                "for mTLS"
+                "Must provide both client_cert_path and client_key_path for mTLS"
             )
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,6 @@ def model_name(request: pytest.FixtureRequest):
 
 
 @pytest.fixture(
-    autouse=True,
     scope="session",
     params=[ConnectionType.INSECURE, ConnectionType.TLS, ConnectionType.MTLS],
 )

--- a/tests/fixtures/http.py
+++ b/tests/fixtures/http.py
@@ -35,7 +35,7 @@ def http_client(
     else:
         host, port = request.getfixturevalue("http_server_thread")
 
-    kwargs: dict[str, str] = {}
+    kwargs: dict = {}
 
     if connection_type is ConnectionType.INSECURE:
         url = f"http://{host}:{port}"

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -8,6 +8,16 @@ from requests.exceptions import SSLError
 from .conftest import ConnectionType
 
 
+def test_client_invalid_args():
+    with pytest.raises(
+        TypeError, match=".* missing 1 required positional argument: 'base_url'"
+    ):
+        HttpClient()
+
+    with pytest.raises(ValueError, match="Cannot use insecure with ca_cert_path"):
+        HttpClient("dummy_base_url", insecure=True, ca_cert_path="dummy")
+
+
 def test_generate_text(
     http_client, model_name, prompt, mocker, accept_self_signed_certs
 ):
@@ -207,6 +217,10 @@ def test_tls_enabled(
         monkeypatch.setenv("REQUESTS_CA_BUNDLE", ca_cert_file)
 
         assert http_client.generate_text(model_name, "dummy text")
+
+    # setting insecure should make the request go through
+    http_client = HttpClient("https://{}:{}".format(*http_server), insecure=True)
+    assert http_client.generate_text(model_name, "dummy text")
 
 
 @pytest.mark.parametrize("connection_type", [ConnectionType.MTLS], indirect=True)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -230,11 +230,16 @@ def test_client_instantiation(
     client_cert_file,
     connection_type,
 ):
-    # MTLS tests
+    """mTLS tests"""
+
+    # should not raise when providing a CA bundle
+    HttpClient(
+        "https://localhost:8080",
+        ca_cert_path=ca_cert_file,
+    )
     with pytest.raises(
         ValueError,
-        match="Must provide both ca_cert_path, client_cert_path, client_key_path for "
-        "mTLS",
+        match="Must provide both client_cert_path and client_key_path for mTLS",
     ):
         HttpClient(
             "https://localhost:8080",


### PR DESCRIPTION
By removing autouse in the `connection_type` fixture, we will only parametrize over tests which use `connection_type`. Since the client fixtures use connection_type, we're automatically parametrizing for all client tests (and skipping the ones which do not need parametrizing)
