### PR TITLE
grpc client: fix grpc insecure mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ To use the gRPC protocol
 ```python
 from caikit_nlp_client import GrpcClient
 
-host = "localhost"
-port = 8085
+host, port= "localhost", 8085
 model_name = "flan-t5-small-caikit"
-grpc_client = GrpcClient(host, port)
+grpc_client = GrpcClient(host, port, insecure=True) # plain text mode
 
 text = grpc_client.generate_text(model_name, "What is the boiling point of Nitrogen?")
 ```
@@ -60,7 +59,7 @@ for param, default_value in client.get_text_generation_parameters():
 
 ### Self-signed certificates
 
-To use a self signed certificate, assuming we have a certificate authority cert `ca.pem`
+To use a self-signed certificate, assuming we have a certificate authority cert `ca.pem`
 
 ```python
 http_client = HttpClient(f"https://{host}:{http_port}", ca_cert_path="ca.pem")
@@ -70,13 +69,13 @@ with open("ca.pem", "rb") as fh:
 grpc_client = GrpcClient(host, grpc_port, ca_cert=ca_cert)
 ```
 
-To skip validation altogether:
+To skip certificate validation:
 
 ```python
 # http
 http_client = HttpClient(f"https://{host}:{http_port}", insecure=True)
 # grpc
-grpc_client = GrpcClient(host, port, insecure=True)
+grpc_client = GrpcClient(host, port, verify=False)
 ```
 
 ### mTLS
@@ -105,7 +104,7 @@ grpc_client = GrpcClient(
     port,
     ca_cert=ca_cert,
     client_key=client_key,
-    client_cert
+    client_cert=client_cert,
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To skip certificate validation:
 
 ```python
 # http
-http_client = HttpClient(f"https://{host}:{http_port}", insecure=True)
+http_client = HttpClient(f"https://{host}:{http_port}", verify=False)
 # grpc
 grpc_client = GrpcClient(host, port, verify=False)
 ```

--- a/examples/example.py
+++ b/examples/example.py
@@ -60,14 +60,14 @@ with open("ca.pem", "rb") as fh:
 # Using a self-signed CA Certificate with the grpc client
 grpc_client = GrpcClient(host, grpc_port, ca_cert=ca_cert)
 
-# Using the grpc client skipping remote host certificate(s) verification
-grpc_client = GrpcClient(host=host, port=grpc_port, verify=False)
+# Using the http client skipping remote host certificate(s) verification
+http_client = HttpClient(f"https://{host}", verify=False)
 text = grpc_client.generate_text("flan-t5-small-caikit", text)
 print(text)
 # 'this is the generated text'
 
-# Using the http client skipping remote host certificate(s) verification
-http_client = HttpClient(f"https://{host}", verify=False)
+# Using the grpc client skipping remote host certificate(s) verification
+grpc_client = GrpcClient(host=host, port=grpc_port, verify=False)
 text = grpc_client.generate_text("flan-t5-small-caikit", text)
 print(text)
 # 'this is the generated text'

--- a/examples/example.py
+++ b/examples/example.py
@@ -19,7 +19,7 @@ print(generated_text)
 # {"generated_text": "...", "generated_tokens": 20, "finish_reason": "MAX_TOKENS", "producer_id": {"name": "Text Generation", "version": "0.1.0"}, "input_token_count": 11, "seed": null}
 
 
-# using the grpc client
+# using the grpc client using insecure (no encryption)
 grpc_client = GrpcClient(host=host, port=grpc_port, insecure=True)
 text = grpc_client.generate_text(
     "flan-t5-small-caikit", text, min_new_tokens=20, max_new_tokens=20
@@ -27,9 +27,10 @@ text = grpc_client.generate_text(
 print(text)
 # 'this is the generated text'
 
+
 # using a context manager (grpc only):
 # (makes sure that the underlying resources are cleaned)
-with GrpcClient(host, port=grpc_port, insecure=True) as client:
+with GrpcClient(host, port=grpc_port) as client:
     text = client.generate_text(
         "flan-t5-small-caikit", text, min_new_tokens=20, max_new_tokens=20
     )
@@ -50,9 +51,23 @@ for chunk in http_client.generate_text_stream("flan-t5-small-caikit", text):
 print(f"generated text: {''.join(chunks)}")
 
 
-# Using a self-signed CA Certificate
+# Using a self-signed CA Certificate with the http client
 http_client = HttpClient(f"https://{host}:{http_port}", ca_cert_path="ca.pem")
 
 with open("ca.pem", "rb") as fh:
     ca_cert = fh.read()
+
+# Using a self-signed CA Certificate with the grpc client
 grpc_client = GrpcClient(host, grpc_port, ca_cert=ca_cert)
+
+# Using the grpc client skipping remote host certificate(s) verification
+grpc_client = GrpcClient(host=host, port=grpc_port, verify=False)
+text = grpc_client.generate_text("flan-t5-small-caikit", text)
+print(text)
+# 'this is the generated text'
+
+# Using the http client skipping remote host certificate(s) verification
+http_client = HttpClient(f"https://{host}", verify=False)
+text = grpc_client.generate_text("flan-t5-small-caikit", text)
+print(text)
+# 'this is the generated text'

--- a/src/caikit_nlp_client/grpc_client.py
+++ b/src/caikit_nlp_client/grpc_client.py
@@ -42,18 +42,14 @@ class GrpcClient:
         >>> )
         """
 
-        try:
-            self._channel = self._make_channel(
-                host,
-                port,
-                insecure=insecure,
-                client_key=client_key,
-                client_cert=client_cert,
-                ca_cert=ca_cert,
-            )
-        except grpc._channel._MultiThreadedRendezvous as exc:
-            log.error("Could not connect to the server: %s", exc.details)
-            raise RuntimeError(f"Could not connect to {host}:{port}") from None
+        self._channel = self._make_channel(
+            host,
+            port,
+            insecure=insecure,
+            client_key=client_key,
+            client_cert=client_cert,
+            ca_cert=ca_cert,
+        )
 
         self._reflection_db = ProtoReflectionDescriptorDatabase(self._channel)
         self._desc_pool = DescriptorPool(self._reflection_db)
@@ -83,6 +79,11 @@ class GrpcClient:
                 request_serializer=self._task_text_generation_request.SerializeToString,
                 response_deserializer=self._generated_text_result.FromString,
             )
+        except grpc._channel._MultiThreadedRendezvous as exc:
+            log.error("Could not connect to the server: %s", exc.details())
+            raise RuntimeError(
+                f"Could not connect to {host}:{port}:" f"{exc.details()}"
+            ) from None
         except KeyError as exc:
             log.error("The grpc server does not have the type: %s", exc)
             raise ValueError(str(exc)) from exc

--- a/src/caikit_nlp_client/grpc_client.py
+++ b/src/caikit_nlp_client/grpc_client.py
@@ -264,10 +264,10 @@ class GrpcClient:
                 private_key=client_key,
                 certificate_chain=client_cert,
             )
-        else:
-            raise ValueError("mTLS requires client_cert, client_key and ca_cert")
 
         return grpc.secure_channel(
             connection,
-            grpc.ssl_channel_credentials(**credentials_kwargs),
+            grpc.ssl_channel_credentials(**credentials_kwargs)
+            if credentials_kwargs
+            else grpc.ssl_channel_credentials(),
         )

--- a/src/caikit_nlp_client/http_client.py
+++ b/src/caikit_nlp_client/http_client.py
@@ -18,7 +18,7 @@ class HttpClient:
     def __init__(
         self,
         base_url: str,
-        insecure: Optional[bool] = None,
+        verify: Optional[bool] = None,
         ca_cert_path: Optional[str] = None,
         client_cert_path: Optional[str] = None,
         client_key_path: Optional[str] = None,
@@ -35,9 +35,9 @@ class HttpClient:
 
         to skip verification of TLS certs:
 
-        >>> client = HttpClient("https://localhost:8080", insecure=True)
+        >>> client = HttpClient("https://localhost:8080", verify=False)
 
-        to use a custom CA (cannot be used with `insecure`):
+        to use a custom CA:
 
         >>> client = HttpClient("https://localhost:8080", ca_cert_path=path)
 
@@ -60,10 +60,10 @@ class HttpClient:
         self._api_url = f"{base_url}{text_generation_endpoint}"
         self._stream_api_url = f"{base_url}{text_generation_stream_endpoint}"
 
-        if insecure is not None and ca_cert_path:
-            raise ValueError("Cannot use insecure with ca_cert_path")
+        if verify is False and ca_cert_path:
+            raise ValueError("Cannot use verify=False with ca_cert_path")
 
-        self._insecure = insecure
+        self._verify = verify
 
         self._client_cert_path = client_cert_path
         self._client_key_path = client_key_path
@@ -93,16 +93,8 @@ class HttpClient:
 
         if self._ca_cert_path:
             req_kwargs["verify"] = self._ca_cert_path
-
-        if self._insecure is not None:
-            if self._ca_cert_path:
-                import warnings
-
-                warnings.warn(
-                    f"insecure={self._insecure} has overridden ca_cert_path",
-                    stacklevel=2,
-                )
-            req_kwargs["verify"] = not self._insecure
+        elif self._verify is not None:
+            req_kwargs["verify"] = self._verify
 
         return req_kwargs
 

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -19,7 +19,7 @@ def get_random_port():
 
 
 class ConnectionType(Enum):
-    INSECURE = 1
+    INSECURE = 1  # grpc insecure (plaintext)
     TLS = 2
     MTLS = 3
 

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -14,8 +14,8 @@ def test_client_invalid_args():
     ):
         HttpClient()
 
-    with pytest.raises(ValueError, match="Cannot use insecure with ca_cert_path"):
-        HttpClient("dummy_base_url", insecure=True, ca_cert_path="dummy")
+    with pytest.raises(ValueError, match="Cannot use verify=False with ca_cert_path"):
+        HttpClient("dummy_base_url", verify=False, ca_cert_path="dummy")
 
 
 def test_generate_text(
@@ -246,8 +246,8 @@ def test_tls_enabled(
 
         assert http_client.generate_text(model_name, "dummy text")
 
-    # setting insecure should make the request go through
-    http_client = HttpClient("https://{}:{}".format(*http_server), insecure=True)
+    # setting verify=False should make the request go through
+    http_client = HttpClient("https://{}:{}".format(*http_server), verify=False)
     assert http_client.generate_text(model_name, "dummy text")
 
 


### PR DESCRIPTION
- grpc client: catch exceptions on grpc connection failure
- grpc client: allow connection to TLS endpoints without providing certificates
- grpc client: add verify option
- http client: rename `insecure` argument to `verify`
