### PR TITLE
feat(clients): :sparkles: Make GrpcClient accepting filepaths instead of certificate/keys bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ grpc_client = GrpcClient(
     client_key=client_key,
     client_cert=client_cert,
 )
+# alternatively you can pass the paths directly to the client constructor
+grpc_client = GrpcClient(
+    host,
+    port,
+    ca_cert="ca.pem",
+    client_cert="client.pem",
+    client_key="client-key.pem"
+)
 ```
 
 ## Contributing

--- a/tests/fixtures/grpc.py
+++ b/tests/fixtures/grpc.py
@@ -41,22 +41,22 @@ def grpc_server_thread_port():
 def grpc_client(
     grpc_server,
     connection_type,
-    ca_cert,
-    client_key,
-    client_cert,
+    ca_cert_file,
+    client_key_file,
+    client_cert_file,
 ) -> GrpcClient:
     if connection_type is ConnectionType.INSECURE:
         return GrpcClient(*grpc_server, insecure=True)
 
     if connection_type is ConnectionType.TLS:
-        return GrpcClient(*grpc_server, ca_cert=ca_cert)
+        return GrpcClient(*grpc_server, ca_cert=ca_cert_file)
 
     if connection_type is ConnectionType.MTLS:
         return GrpcClient(
             *grpc_server,
-            ca_cert=ca_cert,
-            client_key=client_key,
-            client_cert=client_cert,
+            ca_cert=ca_cert_file,
+            client_key=client_key_file,
+            client_cert=client_cert_file,
         )
 
     raise ValueError(f"invalid {connection_type=}")


### PR DESCRIPTION
Updated the grpc client to accept either a path (string) to the cerificate file or a byte array with the cerificate contents

Closes #74