### PR TITLE
grpc client: fix verify=None for some cases

### DIFF
--- a/src/caikit_nlp_client/grpc_client.py
+++ b/src/caikit_nlp_client/grpc_client.py
@@ -1,7 +1,8 @@
 import logging
-import ssl
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Optional, Union
+
+from .utils import get_server_certificate
 
 if TYPE_CHECKING:
     from google._upb._message import Descriptor, Message
@@ -316,7 +317,7 @@ class GrpcClient:
                 port,
             )
 
-            cert = ssl.get_server_certificate((host, port)).encode()
+            cert = get_server_certificate(host, port).encode()
             credentials_kwargs.update(root_certificates=cert)
 
         return grpc.secure_channel(

--- a/src/caikit_nlp_client/utils.py
+++ b/src/caikit_nlp_client/utils.py
@@ -1,0 +1,28 @@
+import socket
+import ssl
+import sys
+
+
+def get_server_certificate(host: str, port: int) -> str:
+    """connect to host:port and get the certificate it presents
+
+    This is almost the same as `ssl.get_server_certificate`, but
+    when opening the TLS socket, `server_hostname` is also provided.
+
+    This retrieves the correct certificate for hosts using name-based
+    virtual hosting.
+    """
+    if sys.version_info >= (3, 10):
+        # ssl.get_server_certificate supports TLS SNI only above 3.10
+        # https://github.com/python/cpython/pull/16820
+        return ssl.get_server_certificate((host, port))
+
+    context = ssl.SSLContext()
+
+    with socket.create_connection((host, port)) as sock, context.wrap_socket(
+        sock, server_hostname=host
+    ) as ssock:
+        cert_der = ssock.getpeercert(binary_form=True)
+
+    assert cert_der
+    return ssl.DER_cert_to_PEM_cert(cert_der)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+import threading
+import time
+
+import fastapi
+import pytest
+import uvicorn
+from caikit_nlp_client.utils import get_server_certificate
+
+from tests.fixtures.utils import get_random_port
+
+
+@pytest.fixture
+def app():
+    app = fastapi.FastAPI()
+
+    @app.route
+    def main():
+        return "ok"
+
+    return app
+
+
+@pytest.fixture
+def server(app, server_key_file, server_cert_file):
+    port = get_random_port()
+    server = uvicorn.Server(
+        config=uvicorn.Config(
+            app,
+            port=port,
+            ssl_keyfile=server_key_file,
+            ssl_certfile=server_cert_file,
+        )
+    )
+
+    t = threading.Thread(target=server.run)
+
+    t.start()
+    while not server.started:
+        time.sleep(1e-3)
+
+    yield "localhost", port
+
+    server.should_exit = True
+    t.join()
+
+
+def test_get_server_certificate(server, server_cert):
+    host, port = server
+    assert get_server_certificate(host, port) == server_cert


### PR DESCRIPTION
`verify=False` used `ssl.get_server_certificate` to get the server certificates. Unfortunately this does not provide a server hostname (TLS SNI), causing the wrong certificates to be fetched when connecting to an host using name-based virtual hosting. This can be solved by providing `server_hostname` when wrapping the socket for TLS.

fixes #80