### PR TITLE
deps: relax dependencies

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -14,10 +14,6 @@ nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = ("pre-commit", "mypy", "tests", "build")
 
 
-# see note regarding caikit_nlp in pyproject.toml
-caikit_nlp_version = "caikit-nlp @ git+https://github.com/caikit/caikit-nlp@0.3.0"
-
-
 def activate_virtualenv_in_precommit_hooks(session: nox.Session) -> None:
     """Activate virtualenv in hooks installed by pre-commit.
 
@@ -119,7 +115,6 @@ def mypy(session: nox.Session) -> None:
     session.install(
         "--index-url=https://download.pytorch.org/whl/cpu", "torch"
     )  # use torch-cpu to speed up tests
-    session.install(caikit_nlp_version)
     session.install(".[dev,tests]")
     session.run("python", "-m", "mypy", *args)
     if not session.posargs:
@@ -132,7 +127,6 @@ def tests(session: nox.Session) -> None:
     session.install(
         "--index-url=https://download.pytorch.org/whl/cpu", "torch"
     )  # use torch-cpu to speed up tests
-    session.install(caikit_nlp_version)
     session.install(".[tests]")
     try:
         session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,7 @@ tests = [
     "pytest-mock",
     "coverage[toml]",
     "grpcio-health-checking",
-    # NOTE: caikit-nlp is not on pypi because of a git dependency (see
-    # https://github.com/caikit/caikit-nlp/issues/263), so we cannot
-    # list it as test dependency here if we want to publish this on pypi.
-    # this install is currently offloaded to `noxfile.py`
-    #"caikit-nlp @ git+https://github.com/caikit/caikit-nlp@0.3.0",
+    "caikit-nlp==0.4.1",
     "caikit[runtime-grpc,runtime-http]>=0.23.2,<0.26.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,9 @@ authors = [
 requires-python = ">=3.9"
 
 dependencies = [
-    "grpcio-reflection==1.59.3",
-    "requests==2.31.0"
+    "protobuf>=4.22.0",
+    "grpcio-reflection>=1.49.3",
+    "requests>=2.22",
 ]
 
 [project.urls]
@@ -46,13 +47,13 @@ version_file = "src/caikit_nlp_client/_version.py"
 [project.optional-dependencies]
 dev = [
     "ruff==0.1.7",
-    "grpcio-tools==1.59.3",
+    "grpcio-tools>=1.49.3",
     "caikit_nlp_client[types]"
 ]
 types = [
     "mypy==1.7.1",
-    "types-requests==2.31.0.10",
-    "types-protobuf==4.24.0.4"
+    "types-requests>=2.22.0.10",
+    "types-protobuf>=4.22.0.0"
 ]
 tests = [
     "pytest",


### PR DESCRIPTION
- pin `protobuf>=4.22.0` (introduction of `GetMessageClass`)
- relax dependencies on `grpcio-reflection` and `requests`

