### PR TITLE
fix handling of errors in stream responses

### DIFF
--- a/src/caikit_nlp_client/http_client.py
+++ b/src/caikit_nlp_client/http_client.py
@@ -247,9 +247,15 @@ class HttpClient:
         buffer: list[bytes] = []
         for line in response.iter_lines():
             if line:
-                # the first 6 bytes contain "data: ", we can skip those
-                buffer.append(line[6:])
-                continue
+                if line.startswith(b"data: "):
+                    buffer.append(line[6:])
+                    continue
+                if line.startswith(b"event: message"):
+                    assert not line[14:]
+                    continue
+                if line.startswith(b"event: error"):
+                    assert not line[12:]
+                    continue
 
             try:
                 message = json.loads(b"".join(buffer))

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,3 +1,4 @@
+import re
 from types import GeneratorType
 
 import pytest
@@ -165,9 +166,7 @@ def test_request_exception_handling(
         prompt = "dummy"
         detail = "Value out of range: -1"
         match = f"{exc_prefix} {detail}"
-        match_stream = (
-            f"{stream_exc_prefix} Unhandled exception: Value out of range: -1"
-        )
+        match_stream = re.escape(f"{stream_exc_prefix} ValueError('{detail}')")
         kwargs = {
             # provide invalid kwargs
             "min_new_tokens": -1,


### PR DESCRIPTION
caikit's improved handling of errors in streaming cases breaks our streaming parsing logic by adding new `event: error` lines in the output.
