### PR TITLE
gha: downgrade codecov to v3 to allow for tokenless upload

### DIFF
--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -55,7 +55,7 @@ jobs:
           nox --session tests-${{ matrix.python }} -- --real-caikit --cov-report=xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v3
         if: always()
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
           nox --session tests-${{ matrix.python }} -- --cov-report=xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v3
         if: always()
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
See https://github.com/codecov/codecov-action/issues/1293
